### PR TITLE
feat: pass mqtt_broker_type to infra module for IoT Core support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ provider "aws" {
 }
 
 module "spacelift" {
-  source = "github.com/spacelift-io/terraform-aws-eks-spacelift-selfhosted?ref=v3.1.0"
+  source = "github.com/spacelift-io/terraform-aws-eks-spacelift-selfhosted?ref=v3.4.4"
 
   aws_region = var.aws_region
 
-  eks_cluster_version = "1.34" # Optional: Kubernetes version. Omit to use latest available version.
+  eks_cluster_version = "1.34" # Optional: Kubernetes version. Omit to use latest available version (recommended).
   rds_engine_version  = "17.7" # Postgres version
 
   # Optional: Set upgrade policy to STANDARD for more frequent upgrades and lower cost

--- a/examples/without-auto-mode/main.tf
+++ b/examples/without-auto-mode/main.tf
@@ -3,14 +3,17 @@ data "aws_rds_engine_version" "postgres" {
   latest = true
 }
 
+data "aws_eks_cluster_versions" "this" {
+  default_only = true
+}
+
 module "spacelift_eks_selfhosted" {
   source = "../../"
 
-  aws_region         = var.aws_region
-  server_domain      = "test.spacelift.example.com"
-  rds_engine_version = data.aws_rds_engine_version.postgres.version_actual
-
-  eks_cluster_version = "1.32"
+  aws_region          = var.aws_region
+  server_domain       = "test.spacelift.example.com"
+  rds_engine_version  = data.aws_rds_engine_version.postgres.version_actual
+  eks_cluster_version = data.aws_eks_cluster_versions.this.cluster_versions[0].cluster_version
 
   eks_upgrade_policy = {
     support_type = "STANDARD"
@@ -23,9 +26,9 @@ module "spacelift_eks_selfhosted" {
     spacelift = {
       ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m5.large"]
-      min_size       = 2
+      min_size       = 1
       max_size       = 4
-      desired_size   = 2
+      desired_size   = 1
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -30,11 +30,13 @@ locals {
 }
 
 module "spacelift" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v2.1.1"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v2.2.0"
 
   unique_suffix    = local.unique_suffix
   region           = var.aws_region
   website_endpoint = "https://${var.server_domain}"
+
+  mqtt_broker_type = var.mqtt_broker_type
 
   kms_arn                       = var.kms_arn
   kms_master_key_multi_regional = var.kms_master_key_multi_regional


### PR DESCRIPTION
When mqtt_broker_type is set to "iotcore", the `terraform-aws-spacelift-selfhosted` submodule now creates the aws_iot_topic_rule and associated IAM resources needed to route MQTT messages from spacelift/writeonly/# to the SQS queue. Without this, worker messages (heartbeats, worker_ready, run_complete) never reach the drain and runs get stuck after job assignment.