### PR TITLE
Allow configuring EKS API endpoint access

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ module "spacelift" {
     support_type = "STANDARD"
   }
 
+  # Optional: make the EKS API private-only.
+  eks_endpoint_public_access  = false
+  eks_endpoint_private_access = true
+
   # The domain you want to host Spacelift on, for example spacelift.example.com.
   server_domain = var.server_domain
 }

--- a/eks.tf
+++ b/eks.tf
@@ -24,8 +24,8 @@ module "eks" {
   kubernetes_version = var.eks_cluster_version
   upgrade_policy     = var.eks_upgrade_policy
 
-  # The Kubernetes API endpoint will be accessible via the public internet.
-  endpoint_public_access = true
+  endpoint_public_access  = var.eks_endpoint_public_access
+  endpoint_private_access = var.eks_endpoint_private_access
 
   # Adds the current caller identity as an administrator via cluster access entry. This is required
   # in order to install the cluster addons.

--- a/variables.tf
+++ b/variables.tf
@@ -609,6 +609,18 @@ variable "eks_cluster_version" {
   default     = null
 }
 
+variable "eks_endpoint_public_access" {
+  type        = bool
+  description = "Whether the EKS Kubernetes API endpoint should be reachable over the public internet."
+  default     = true
+}
+
+variable "eks_endpoint_private_access" {
+  type        = bool
+  description = "Whether the EKS Kubernetes API endpoint should be reachable from within the VPC."
+  default     = true
+}
+
 variable "eks_upgrade_policy" {
   type = object({
     support_type = string


### PR DESCRIPTION
This makes EKS API endpoint access configurable instead of always forcing a public control plane. The default behavior stays the same, but callers can now set `eks_endpoint_public_access = false` to use a private-only EKS API without forking the module.