### PR TITLE
feat: bump selfhosted to v2.3.0 and expose RDS Data API toggle

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ locals {
 }
 
 module "spacelift" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v2.2.0"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v2.3.0"
 
   unique_suffix    = local.unique_suffix
   region           = var.aws_region
@@ -77,6 +77,7 @@ module "spacelift" {
   rds_preferred_backup_window            = var.rds_preferred_backup_window
   rds_backup_retention_period            = var.rds_backup_retention_period
   rds_apply_immediately                  = var.rds_apply_immediately
+  rds_enable_http_endpoint               = var.rds_enable_http_endpoint
 
   s3_bucket_configuration          = var.s3_bucket_configuration
   s3_retain_on_destroy             = var.s3_retain_on_destroy

--- a/variables.tf
+++ b/variables.tf
@@ -245,6 +245,12 @@ variable "rds_apply_immediately" {
   default     = true
 }
 
+variable "rds_enable_http_endpoint" {
+  type        = bool
+  description = "Whether to enable the Data API (HTTP endpoint) for the RDS cluster. This also unlocks the query editor in the RDS console, letting you run SQL against the database without a bastion or local client. Only available for Aurora Serverless v2 and provisioned clusters in supported regions, see https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html#data-api.regions for the list."
+  default     = null
+}
+
 ### S3
 
 variable "s3_bucket_configuration" {


### PR DESCRIPTION
## What

Bumps the upstream `terraform-aws-spacelift-selfhosted` module from `v2.2.0` to `v2.3.0` and exposes the new `rds_enable_http_endpoint` variable it introduced.

## Why

v2.3.0 adds support for enabling the [RDS Data API (HTTP endpoint)](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html). Wiring the input through here lets operators turn it on (which also unlocks the RDS console query editor) so they can run SQL against the database without standing up a bastion or local client.

The variable defaults to `null`, so existing deployments inherit the upstream module's default behavior and nothing changes unless it's explicitly set.