### PR TITLE
refactor: use one() for count-gated ebs_kms_key_id output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -346,7 +346,7 @@ output "ebs_kms_key_arn" {
 }
 
 output "ebs_kms_key_id" {
-  value       = local.create_ebs_key ? aws_kms_key.ebs[0].key_id : null
+  value       = one(aws_kms_key.ebs[*].key_id)
   description = "ID of the KMS key used for EBS volume encryption. Only set when account_enforces_ebs_encryption is true."
 }
 


### PR DESCRIPTION
## Why

`one()` returns the single element of a 0-or-1 element list, or `null` when empty. Behavior-identical, and reads as intent instead of index juggling.